### PR TITLE
Fix: Supabase keep-alive 크론 스케줄을 3일 간격으로 변경

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/keep-alive",
-      "schedule": "0 0 */5 * *"
+      "schedule": "0 0 */3 * *"
     }
   ]
 }


### PR DESCRIPTION
- vercel.json의 크론 스케줄을 5일에서 3일 간격으로 수정
- Supabase 자동 활성화가 더 자주 이루어지도록 개선