### PR TITLE
Fix: vercel.json을 yu-calendar 루트로 이동 및 크론을 매일 1회로 변경

### DIFF
--- a/packages/yu-calendar/vercel.json
+++ b/packages/yu-calendar/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/keep-alive",
-      "schedule": "0 0 */3 * *"
+      "schedule": "0 0 * * *"
     }
   ]
 }


### PR DESCRIPTION
- vercel.json 파일을 yu-calendar 패키지의 루트로 이동
- 크론 스케줄을 매일 1회(0시) 실행으로 수정하여 자동 활성화 주기 개선