### PR TITLE
Fix: Vercel 크론 트리거가 동작하지 않는 문제 수정

### DIFF
--- a/packages/yu-calendar/src/app/api/keep-alive/route.ts
+++ b/packages/yu-calendar/src/app/api/keep-alive/route.ts
@@ -1,4 +1,6 @@
 // src/app/api/keep-alive/route.ts
+export const dynamic = "force-dynamic";
+
 import { keepAliveToSupabase } from "@/actions/supabaseEventsActions";
 
 export async function GET() {

--- a/packages/yu-calendar/vercel.json
+++ b/packages/yu-calendar/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/keep-alive",
-      "schedule": "0 0 * * *"
+      "schedule": "0 15 * * *"
     }
   ]
 }


### PR DESCRIPTION
- /api/keep-alive 라우트에 force-dynamic 옵션 추가
- vercel.json의 크론 스케줄을 한국시간 기준으로 수정 (0 15 * * *)